### PR TITLE
Prepare 21.0.0-next.0 prerelease

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "21.0.0-next.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-select-workspace",
-      "version": "16.0.3",
+      "version": "21.0.0-next.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^21.2.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "21.0.0-next.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/projects/ngx-mat-select/package.json
+++ b/projects/ngx-mat-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select",
-  "version": "16.0.3",
+  "version": "21.0.0-next.0",
   "license": "MIT",
   "author": "Alireza Sohrabi, Tehran IRAN",
   "bugs": {


### PR DESCRIPTION
## Summary
- update the workspace version to 21.0.0-next.0
- update the published library version to 21.0.0-next.0
- align the package lock metadata

## Validation
- npm ci
- npm test -- --progress=false
- npm run verify:public-api
- npm run verify:consumer:21
- npm run verify:consumer:22
- npm run build:library
- npm --prefix tools/npm-publisher-mcp test

## Publishing
Publish with the next dist-tag only after npm authentication and explicit release confirmation.

Closes #76