### PR TITLE
Fix documentation deploy workflow toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,36 @@
 name: Build and Deploy
+
 on:
   push:
     branches:
       - master
+
 permissions:
   contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v5
 
-      - name: Install and Build
-        run: |
-          npm ci
-          npm run build:ci
+      - name: Use Node 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22.x'
+          cache: npm
 
-      - name: Deploy 🚀
+      - name: Use npm 11
+        run: npm install --global npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build documentation
+        run: npm run build:ci
+
+      - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: demo
+          folder: dist/demo/browser


### PR DESCRIPTION
## What changed

- pin the documentation deployment workflow to Node 22 and npm 11, matching the build workflow
- upgrade checkout and setup-node actions to v5
- deploy the Angular application output from `dist/demo/browser`

## Root cause

The master-only deployment workflow used the runner's implicit npm 10 toolchain. npm 10 rejects the existing npm 11-compatible lockfile as missing transitive `chokidar@5.0.0` and `readdirp@5.0.0` entries. The deployment folder also still pointed to the pre-migration `demo` path instead of the current Angular application output.

## Impact

Master builds can install dependencies consistently and publish the generated documentation site from the correct directory.

## Validation

- `npm ci`
- `npm run build:ci`
- `npm test -- --progress=false` (12 tests)
- `npm run verify:public-api`
- `npm run verify:consumer:21` (3 tests plus production build)
- `npm run verify:consumer:22` (3 tests plus production build)
- `npm --prefix tools/npm-publisher-mcp test` (4 tests)