### PR TITLE
Prepare ngx-mat-select 18.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,15 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node 18.x
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v5
+      - name: Use Node 20.x
+        uses: actions/setup-node@v5
         with:
-          node-version: '18.x'
+          node-version: '20.x'
+          cache: npm
+      - name: Use npm 11
+        run: npm install --global npm@11
       - name: Install dependencies
         run: npm ci
       - name: Build
         run: npm run build:ci
+      - name: Test
+        run: npm test -- --progress=false
       - name: Archive build
         if: success()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ RLT support (use dir='rtl' in html tag)
 
 | Angular Material | 	NgxMatSelect |
 |------------------|---------------|
+| 18.x.x           | 	18.x        |
+| 17.x.x           | 	17.x        |
 | 16.x.x           | 	>= 16        | 
 | 15.x.x           | 	>= 15        | 
 | 14.x.x           | 	>= 14        | 
@@ -84,6 +86,5 @@ RLT support (use dir='rtl' in html tag)
                   panelHeight?: number;
                 }}
       ],
-
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "18.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-select-workspace",
-      "version": "16.0.3",
+      "version": "18.0.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^18.2.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "18.0.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/projects/ngx-mat-select/README.md
+++ b/projects/ngx-mat-select/README.md
@@ -25,6 +25,8 @@ RLT support (use dir='rtl' in html tag)
 
 | Angular Material | 	NgxMatSelect |
 |------------------|---------------|
+| 18.x.x           | 	18.x        |
+| 17.x.x           | 	17.x        |
 | 16.x.x           | 	>= 16        |
 | 15.x.x           | 	>= 15        |
 | 14.x.x           | 	>= 14        |
@@ -84,6 +86,5 @@ RLT support (use dir='rtl' in html tag)
                   panelHeight?: number;
                 }}
       ],
-
 
 

--- a/projects/ngx-mat-select/package.json
+++ b/projects/ngx-mat-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select",
-  "version": "16.0.3",
+  "version": "18.0.0",
   "license": "MIT",
   "author": "Alireza Sohrabi, Tehran IRAN",
   "bugs": {


### PR DESCRIPTION
## What changed

- assign the Angular 18 checkpoint the release version `18.0.0`
- update the root and packaged compatibility tables
- preserve Angular 18-only peer dependency ranges

## Why

The Angular 18 migration checkpoint was previously marked as `16.0.3` and could not be safely published as its own npm major.

## Validation

- clean `npm ci`
- 12/12 library unit tests
- production library build
- packed-artifact inspection
- public TypeScript, selector, and Sass API baseline verification
- clean Angular 18 consumer install, interaction test, and production build

Publication will use the `angular18` npm dist-tag and will not modify `latest`.