### PR TITLE
Prepare ngx-mat-select 19.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,15 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node 18.x
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v5
+      - name: Use Node 20.x
+        uses: actions/setup-node@v5
         with:
-          node-version: '18.x'
+          node-version: '20.x'
+          cache: npm
+      - name: Use npm 11
+        run: npm install --global npm@11
       - name: Install dependencies
         run: npm ci
       - name: Build
         run: npm run build:ci
+      - name: Test
+        run: npm test -- --progress=false
       - name: Archive build
         if: success()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ RLT support (use dir='rtl' in html tag)
 
 | Angular Material | 	NgxMatSelect |
 |------------------|---------------|
+| 19.x.x           | 	19.x        |
+| 18.x.x           | 	18.x        |
+| 17.x.x           | 	17.x        |
 | 16.x.x           | 	>= 16        | 
 | 15.x.x           | 	>= 15        | 
 | 14.x.x           | 	>= 14        | 
@@ -84,6 +87,5 @@ RLT support (use dir='rtl' in html tag)
                   panelHeight?: number;
                 }}
       ],
-
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "19.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-select-workspace",
-      "version": "16.0.3",
+      "version": "19.0.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^19.2.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@ng-doc/core": "19.3.0",
         "@ng-doc/ui-kit": "19.3.0",
         "@types/d3": "^7.4.3",
+        "@types/dompurify": "3.0.5",
         "@types/jasmine": "~4.3.0",
         "angular-cli-ghpages": "^1.0.6",
         "jasmine-core": "~4.6.0",
@@ -8420,6 +8421,16 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -8660,6 +8671,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -30727,6 +30745,15 @@
         "@types/ms": "*"
       }
     },
+    "@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -30945,6 +30972,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
     },
     "@types/unist": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@angular/router": "^19.2.25",
     "@types/jasmine": "~4.3.0",
     "@types/d3": "^7.4.3",
+    "@types/dompurify": "3.0.5",
     "angular-cli-ghpages": "^1.0.6",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "19.0.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/projects/ngx-mat-select/README.md
+++ b/projects/ngx-mat-select/README.md
@@ -25,6 +25,9 @@ RLT support (use dir='rtl' in html tag)
 
 | Angular Material | 	NgxMatSelect |
 |------------------|---------------|
+| 19.x.x           | 	19.x        |
+| 18.x.x           | 	18.x        |
+| 17.x.x           | 	17.x        |
 | 16.x.x           | 	>= 16        |
 | 15.x.x           | 	>= 15        |
 | 14.x.x           | 	>= 14        |
@@ -84,6 +87,5 @@ RLT support (use dir='rtl' in html tag)
                   panelHeight?: number;
                 }}
       ],
-
 
 

--- a/projects/ngx-mat-select/package.json
+++ b/projects/ngx-mat-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select",
-  "version": "16.0.3",
+  "version": "19.0.0",
   "license": "MIT",
   "author": "Alireza Sohrabi, Tehran IRAN",
   "bugs": {


### PR DESCRIPTION
## What changed

- assign the Angular 19 checkpoint the release version `19.0.0`
- update the root and packaged compatibility tables
- preserve Angular 19-only peer dependency ranges

## Why

The Angular 19 migration checkpoint was previously marked as `16.0.3` and could not be safely published as its own npm major.

## Validation

- clean `npm ci`
- 12/12 library unit tests
- production library build
- packed-artifact inspection
- public TypeScript, selector, and Sass API baseline verification
- clean Angular 19 consumer install, interaction test, and production build

Publication will use the `angular19` npm dist-tag and will not modify `latest`.