### PR TITLE
Prepare ngx-mat-select 20.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ RLT support (use dir='rtl' in html tag)
 
 | Angular Material | 	NgxMatSelect |
 |------------------|---------------|
+| 20.x.x           | 	20.x        |
+| 19.x.x           | 	19.x        |
+| 18.x.x           | 	18.x        |
+| 17.x.x           | 	17.x        |
 | 16.x.x           | 	>= 16        | 
 | 15.x.x           | 	>= 15        | 
 | 14.x.x           | 	>= 14        | 
@@ -84,6 +88,5 @@ RLT support (use dir='rtl' in html tag)
                   panelHeight?: number;
                 }}
       ],
-
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "20.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-select-workspace",
-      "version": "16.0.3",
+      "version": "20.0.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^20.3.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "16.0.3",
+  "version": "20.0.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/projects/ngx-mat-select/README.md
+++ b/projects/ngx-mat-select/README.md
@@ -25,6 +25,10 @@ RLT support (use dir='rtl' in html tag)
 
 | Angular Material | 	NgxMatSelect |
 |------------------|---------------|
+| 20.x.x           | 	20.x        |
+| 19.x.x           | 	19.x        |
+| 18.x.x           | 	18.x        |
+| 17.x.x           | 	17.x        |
 | 16.x.x           | 	>= 16        |
 | 15.x.x           | 	>= 15        |
 | 14.x.x           | 	>= 14        |
@@ -84,6 +88,5 @@ RLT support (use dir='rtl' in html tag)
                   panelHeight?: number;
                 }}
       ],
-
 
 

--- a/projects/ngx-mat-select/package.json
+++ b/projects/ngx-mat-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select",
-  "version": "16.0.3",
+  "version": "20.0.0",
   "license": "MIT",
   "author": "Alireza Sohrabi, Tehran IRAN",
   "bugs": {


### PR DESCRIPTION
## What changed

- assign the Angular 20 checkpoint the release version `20.0.0`
- update the root and packaged compatibility tables
- preserve Angular 20-only peer dependency ranges

## Why

The Angular 20 migration checkpoint was previously marked as `16.0.3` and could not be safely published as its own npm major.

## Validation

- clean `npm ci`
- 12/12 library unit tests
- production library build
- packed-artifact inspection
- public TypeScript, selector, and Sass API baseline verification
- clean Angular 20 consumer install, interaction test, and production build

Publication will use the `angular20` npm dist-tag and will not modify `latest`.