### PR TITLE
Support Angular 17 through 21 release train

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ The current npm stable release is `16.0.4`. The repository source is being prepa
 | ngx-mat-select | Angular and Angular Material | Status |
 | --- | --- | --- |
 | `21.0.0-next.0` / `21.x` | `21.x` or `22.x` | Upcoming; verified with clean Angular 21 and 22 consumers |
+| `20.x` | `20.x` | Compatibility release |
+| `19.x` | `19.x` | Compatibility release |
+| `18.x` | `18.x` | Compatibility release |
+| `17.x` | `17.x` | Compatibility release |
 | `16.x` | `16.x` | Current npm stable release |
 | `15.x` | `15.x` | Previous release line |
 | `14.x` | `14.x` | Previous release line |
 
-The Angular 17–20 upgrade checkpoints were used to migrate and validate the source. They are not published package versions.
+The Angular 17–20 compatibility releases preserve the validated migration checkpoints for applications that cannot yet move to Angular 21.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:ci": "npm run build:library && ng build demo --configuration production --progress=false --base-href=/ngx-mat-select/",
     "verify:consumer:21": "node scripts/verify-consumer.mjs 21",
     "verify:consumer:22": "node scripts/verify-consumer.mjs 22",
+    "verify:consumer": "node scripts/verify-consumer.mjs",
     "verify:public-api": "npm run build:library && node scripts/verify-public-api.mjs"
   },
   "author": "Alireze Sohrabi, Tehran IRAN",

--- a/projects/ngx-mat-select/README.md
+++ b/projects/ngx-mat-select/README.md
@@ -20,11 +20,15 @@ The current npm stable release is `16.0.4`. The repository source is being prepa
 | ngx-mat-select | Angular and Angular Material | Status |
 | --- | --- | --- |
 | `21.0.0-next.0` / `21.x` | `21.x` or `22.x` | Upcoming; verified with clean Angular 21 and 22 consumers |
+| `20.x` | `20.x` | Compatibility release |
+| `19.x` | `19.x` | Compatibility release |
+| `18.x` | `18.x` | Compatibility release |
+| `17.x` | `17.x` | Compatibility release |
 | `16.x` | `16.x` | Current npm stable release |
 | `15.x` | `15.x` | Previous release line |
 | `14.x` | `14.x` | Previous release line |
 
-The Angular 17–20 upgrade checkpoints were used to migrate and validate the source. They are not published package versions.
+The Angular 17–20 compatibility releases preserve the validated migration checkpoints for applications that cannot yet move to Angular 21.
 
 ## Installation
 

--- a/scripts/verify-consumer.mjs
+++ b/scripts/verify-consumer.mjs
@@ -10,17 +10,28 @@ import { basename, dirname, join, resolve } from 'node:path';
 
 const major = process.argv[2];
 const withSsr = process.argv.includes('--ssr');
+const packageRootIndex = process.argv.indexOf('--package-root');
 const versions = {
+  '17': { angular: '17.3.12', cli: '17.3.17', material: '17.3.10' },
+  '18': { angular: '18.2.14', cli: '18.2.21', material: '18.2.14' },
+  '19': { angular: '19.2.25', cli: '19.2.27', material: '19.2.19' },
   '20': { angular: '20.3.27', cli: '20.3.33', material: '20.2.14' },
   '21': { angular: '21.2.19', cli: '21.2.20', material: '21.2.14' },
   '22': { angular: '22.1.0', cli: '22.1.3', material: '22.1.1' },
 };
 
 if (!major || !versions[major]) {
-  throw new Error('Usage: node scripts/verify-consumer.mjs <angular-major> [--ssr]');
+  throw new Error(
+    'Usage: node scripts/verify-consumer.mjs <angular-major> [--ssr] [--package-root <path>]',
+  );
+}
+if (packageRootIndex >= 0 && !process.argv[packageRootIndex + 1]) {
+  throw new Error('--package-root requires a path.');
 }
 
-const root = resolve(import.meta.dirname, '..');
+const root = packageRootIndex >= 0
+  ? resolve(process.argv[packageRootIndex + 1])
+  : resolve(import.meta.dirname, '..');
 const workspace = mkdtempSync(join(tmpdir(), `ngx-mat-select-angular-${major}-`));
 const npmCli = process.env.npm_execpath;
 if (!npmCli) throw new Error('Run this verifier through an npm script.');
@@ -158,9 +169,9 @@ describe('packed ngx-mat-select', () => {
 @use 'ngx-mat-select' as ngx-mat-select;
 
 @include mat.core();
-$theme: mat.m2-define-light-theme((color: (
-  primary: mat.m2-define-palette(mat.$m2-indigo-palette),
-  accent: mat.m2-define-palette(mat.$m2-pink-palette)
+$theme: mat.${Number(major) >= 18 ? 'm2-' : ''}define-light-theme((color: (
+  primary: mat.${Number(major) >= 18 ? 'm2-' : ''}define-palette(mat.$${Number(major) >= 18 ? 'm2-' : ''}indigo-palette),
+  accent: mat.${Number(major) >= 18 ? 'm2-' : ''}define-palette(mat.$${Number(major) >= 18 ? 'm2-' : ''}pink-palette)
 )));
 @include mat.all-component-themes($theme);
 @include ngx-mat-select.theme($theme);

--- a/scripts/verify-public-api.mjs
+++ b/scripts/verify-public-api.mjs
@@ -1,11 +1,25 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-const root = resolve(import.meta.dirname, '..');
+const packageRootIndex = process.argv.indexOf('--package-root');
+if (packageRootIndex >= 0 && !process.argv[packageRootIndex + 1]) {
+  throw new Error('--package-root requires a path.');
+}
+const root = packageRootIndex >= 0
+  ? resolve(process.argv[packageRootIndex + 1])
+  : resolve(import.meta.dirname, '..');
 const dist = resolve(root, 'dist/ngx-mat-select');
 const packageJson = JSON.parse(readFileSync(resolve(dist, 'package.json'), 'utf8'));
 const typesPath = resolve(dist, packageJson.exports['.'].types);
-const declarations = readFileSync(typesPath, 'utf8');
+function readDeclarations(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = resolve(directory, entry.name);
+    if (entry.isDirectory()) return readDeclarations(entryPath);
+    return entry.name.endsWith('.d.ts') ? [readFileSync(entryPath, 'utf8')] : [];
+  });
+}
+
+const declarations = [readFileSync(typesPath, 'utf8'), ...readDeclarations(dist)].join('\n');
 const bundle = readFileSync(resolve(dist, packageJson.exports['.'].default), 'utf8');
 
 const exports = [

--- a/tools/npm-publisher-mcp/README.md
+++ b/tools/npm-publisher-mcp/README.md
@@ -3,15 +3,22 @@
 This project-specific STDIO server exposes guarded release tools for `ngx-mat-select`:
 
 - `npm_release_status` checks the repository, registry, and npm authentication.
-- `npm_validate_release` runs the complete release validation and packs the artifact without publishing.
+- `npm_validate_release` runs complete release validation and packs the artifact without publishing.
 - `npm_publish_release` repeats validation and publishes only after receiving an exact confirmation phrase.
 
 The server permits only this release sequence:
 
-1. `21.0.0-next.0` with the `next` dist-tag.
-2. `21.0.0` with the `latest` dist-tag, after the prerelease exists on npm.
+1. `17.0.0` with the `angular17` dist-tag.
+2. `18.0.0` with the `angular18` dist-tag.
+3. `19.0.0` with the `angular19` dist-tag.
+4. `20.0.0` with the `angular20` dist-tag.
+5. `21.0.0-next.0` with the `next` dist-tag.
+6. `21.0.0` with the `latest` dist-tag, after the prerelease exists on npm.
 
-Angular 17–20 versions were migration checkpoints and cannot be published through this server.
+Angular 17–20 releases are built from isolated sibling worktrees named
+`ngx-mat-select-release-17` through `ngx-mat-select-release-20`. This keeps each
+artifact tied to its matching Angular migration checkpoint while the main worktree
+remains on Angular 21.
 
 ## Install
 
@@ -38,7 +45,11 @@ Restart Codex after changing the MCP configuration.
 
 ## Authentication
 
-Use a granular npm access token that can publish `ngx-mat-select`. Keep it outside the repository and expose it as `NPM_TOKEN` before starting Codex. The server writes the token to a temporary npm user configuration for each npm command and removes it immediately afterward. An existing user-level npm login is also supported when `NPM_TOKEN` is unset.
+Use a granular npm access token that can publish `ngx-mat-select`. Keep it outside
+the repository and expose it as `NPM_TOKEN` before starting Codex. The server writes
+the token to a temporary npm user configuration for each npm command and removes it
+immediately afterward. An existing user-level npm login is also supported when
+`NPM_TOKEN` is unset.
 
 Do not put a token in this README, `config.toml`, or any repository file.
 
@@ -47,10 +58,12 @@ Do not put a token in this README, `config.toml`, or any repository file.
 Before validation or publishing:
 
 - both `package.json` files must contain the requested release version;
-- the current branch must be `master`;
+- the current branch must match the version-specific release policy;
 - the working tree must be clean;
 - the version must not already exist on npm;
 - npm authentication must succeed;
-- for `21.0.0`, `21.0.0-next.0` must already exist on npm.
+- every release prerequisite must already exist on npm before publication.
 
-The server runs installation, unit tests, public API validation, Angular 21 and 22 consumer validation, a production library build, and `npm pack` before publishing.
+The server runs installation, unit tests, a production library build, public API
+validation, clean consumer validation for the matching Angular major (plus Angular
+22 for the Angular 21 package), and `npm pack` before publishing.

--- a/tools/npm-publisher-mcp/src/index.mjs
+++ b/tools/npm-publisher-mcp/src/index.mjs
@@ -6,11 +6,19 @@ import {
   confirmationPhrase,
   getStatus,
   publishRelease,
+  resolveReleaseRepository,
   resolveRepository,
   validateRelease,
 } from './release.mjs';
 
-const releaseVersionSchema = z.enum(['21.0.0-next.0', '21.0.0']);
+const releaseVersionSchema = z.enum([
+  '17.0.0',
+  '18.0.0',
+  '19.0.0',
+  '20.0.0',
+  '21.0.0-next.0',
+  '21.0.0',
+]);
 
 function result(value) {
   return {
@@ -45,7 +53,7 @@ export function createServer() {
     { name: 'ngx-mat-select-publisher', version: '1.0.0' },
     {
       instructions:
-        'This server only releases ngx-mat-select. Publish 21.0.0-next.0 with the next tag, validate it, then publish 21.0.0 with the latest tag. Never publish Angular 17-20 checkpoint versions. Always call npm_release_status first, then npm_validate_release, and ask the user for the exact confirmation phrase before npm_publish_release.',
+        'This server only releases ngx-mat-select. Publish 17.0.0 through 20.0.0 from their matching release worktrees with angular-major tags, then publish 21.0.0-next.0 with next, and only later 21.0.0 with latest. Always call npm_release_status first, then npm_validate_release, and ask the user for the exact release-specific confirmation phrase before every npm_publish_release call.',
     },
   );
 
@@ -71,7 +79,7 @@ export function createServer() {
     {
       title: 'Validate an ngx-mat-select release',
       description:
-        'Require a clean master branch and matching unpublished package version, run the full test and consumer validation suite, and inspect the packed artifact without publishing it.',
+        'Require the clean version-specific release branch and matching unpublished package version, run the full test and consumer validation suite, and inspect the packed artifact without publishing it.',
       inputSchema: { version: releaseVersionSchema },
       annotations: {
         readOnlyHint: false,
@@ -80,7 +88,10 @@ export function createServer() {
         openWorldHint: true,
       },
     },
-    guarded(async ({ version }) => validateRelease(version, resolveRepository())),
+    guarded(async ({ version }) => validateRelease(
+      version,
+      resolveReleaseRepository(version, resolveRepository()),
+    )),
   );
 
   server.registerTool(
@@ -88,7 +99,7 @@ export function createServer() {
     {
       title: 'Publish an ngx-mat-select release',
       description:
-        'Run all release checks and publish exactly 21.0.0-next.0 with tag next or 21.0.0 with tag latest. Requires the exact release-specific confirmation phrase.',
+        'Run all release checks and publish one permitted release with its fixed dist-tag. Requires the exact release-specific confirmation phrase.',
       inputSchema: {
         version: releaseVersionSchema,
         confirmation: z.string().describe(
@@ -106,7 +117,11 @@ export function createServer() {
       if (confirmation !== confirmationPhrase(version)) {
         throw new Error(`Confirmation must exactly match: ${confirmationPhrase(version)}`);
       }
-      return publishRelease(version, confirmation, resolveRepository());
+      return publishRelease(
+        version,
+        confirmation,
+        resolveReleaseRepository(version, resolveRepository()),
+      );
     }),
   );
 

--- a/tools/npm-publisher-mcp/src/release.mjs
+++ b/tools/npm-publisher-mcp/src/release.mjs
@@ -5,8 +5,48 @@ import path from 'node:path';
 
 export const PACKAGE_NAME = 'ngx-mat-select';
 export const RELEASES = Object.freeze({
-  '21.0.0-next.0': Object.freeze({ tag: 'next', prerequisite: null }),
-  '21.0.0': Object.freeze({ tag: 'latest', prerequisite: '21.0.0-next.0' }),
+  '17.0.0': Object.freeze({
+    tag: 'angular17',
+    prerequisite: null,
+    branch: 'release/17.0.0',
+    angularMajors: ['17'],
+    repositorySuffix: '-release-17',
+  }),
+  '18.0.0': Object.freeze({
+    tag: 'angular18',
+    prerequisite: '17.0.0',
+    branch: 'release/18.0.0',
+    angularMajors: ['18'],
+    repositorySuffix: '-release-18',
+  }),
+  '19.0.0': Object.freeze({
+    tag: 'angular19',
+    prerequisite: '18.0.0',
+    branch: 'release/19.0.0',
+    angularMajors: ['19'],
+    repositorySuffix: '-release-19',
+  }),
+  '20.0.0': Object.freeze({
+    tag: 'angular20',
+    prerequisite: '19.0.0',
+    branch: 'release/20.0.0',
+    angularMajors: ['20'],
+    repositorySuffix: '-release-20',
+  }),
+  '21.0.0-next.0': Object.freeze({
+    tag: 'next',
+    prerequisite: '20.0.0',
+    branch: 'master',
+    angularMajors: ['21', '22'],
+    repositorySuffix: '',
+  }),
+  '21.0.0': Object.freeze({
+    tag: 'latest',
+    prerequisite: '21.0.0-next.0',
+    branch: 'master',
+    angularMajors: ['21', '22'],
+    repositorySuffix: '',
+  }),
 });
 
 const MAX_OUTPUT_LENGTH = 12000;
@@ -37,6 +77,11 @@ export function confirmationPhrase(version) {
 export function resolveRepository(repositoryPath = process.env.NGX_MAT_SELECT_REPO) {
   const configuredPath = repositoryPath || 'D:\\ngx-mat-select';
   return path.resolve(configuredPath);
+}
+
+export function resolveReleaseRepository(version, repositoryPath = resolveRepository()) {
+  const release = getRelease(version);
+  return path.resolve(`${repositoryPath}${release.repositorySuffix}`);
 }
 
 function commandInvocation(command, args) {
@@ -179,6 +224,8 @@ export async function getStatus(repositoryPath = resolveRepository()) {
     allowedReleases: Object.entries(RELEASES).map(([version, release]) => ({
       version,
       tag: release.tag,
+      branch: release.branch,
+      repositoryPath: resolveReleaseRepository(version, repositoryPath),
       confirmation: confirmationPhrase(version),
     })),
   };
@@ -196,8 +243,10 @@ async function assertReleaseState(repositoryPath, version) {
   }
 
   const branch = await run('git', ['branch', '--show-current'], { cwd: repositoryPath });
-  if (branch.stdout !== 'master') {
-    throw new ReleaseError(`Releases must be published from master, not ${branch.stdout || 'detached HEAD'}.`);
+  if (branch.stdout !== release.branch) {
+    throw new ReleaseError(
+      `${version} must be released from ${release.branch}, not ${branch.stdout || 'detached HEAD'}.`,
+    );
   }
 
   const changes = await run('git', ['status', '--porcelain'], { cwd: repositoryPath });
@@ -205,14 +254,27 @@ async function assertReleaseState(repositoryPath, version) {
     throw new ReleaseError('The repository must be clean before validation or publishing.');
   }
 
-  if (await registryVersionExists(repositoryPath, version)) {
-    throw new ReleaseError(`${PACKAGE_NAME}@${version} is already published.`);
+  const automationRepository = resolveRepository();
+  if (path.resolve(repositoryPath) !== automationRepository) {
+    const automationBranch = await run(
+      'git',
+      ['branch', '--show-current'],
+      { cwd: automationRepository },
+    );
+    const automationChanges = await run(
+      'git',
+      ['status', '--porcelain'],
+      { cwd: automationRepository },
+    );
+    if (automationBranch.stdout !== 'master' || automationChanges.stdout) {
+      throw new ReleaseError(
+        'Historical releases require the clean automation repository on master.',
+      );
+    }
   }
 
-  if (release.prerequisite && !await registryVersionExists(repositoryPath, release.prerequisite)) {
-    throw new ReleaseError(
-      `${PACKAGE_NAME}@${release.prerequisite} must be published and validated before ${version}.`,
-    );
+  if (await registryVersionExists(repositoryPath, version)) {
+    throw new ReleaseError(`${PACKAGE_NAME}@${version} is already published.`);
   }
 
   const auth = await run('npm', ['whoami'], {
@@ -229,18 +291,48 @@ async function assertReleaseState(repositoryPath, version) {
   return { release, npmUser: auth.stdout };
 }
 
-async function runValidation(repositoryPath) {
+async function assertPrerequisite(repositoryPath, version, release) {
+  if (release.prerequisite && !await registryVersionExists(repositoryPath, release.prerequisite)) {
+    throw new ReleaseError(
+      `${PACKAGE_NAME}@${release.prerequisite} must be published before ${version}.`,
+    );
+  }
+}
+
+async function runValidation(repositoryPath, release) {
   const commands = [
     ['npm', ['ci']],
     ['npm', ['test', '--', '--progress=false']],
-    ['npm', ['run', 'verify:public-api']],
-    ['npm', ['run', 'verify:consumer:21']],
-    ['npm', ['run', 'verify:consumer:22']],
     ['npm', ['run', 'build:library']],
   ];
 
   for (const [command, args] of commands) {
     await run(command, args, { cwd: repositoryPath });
+  }
+
+  const automationRepository = resolveRepository();
+  await run(
+    process.execPath,
+    [
+      path.join(automationRepository, 'scripts', 'verify-public-api.mjs'),
+      '--package-root',
+      repositoryPath,
+    ],
+    { cwd: automationRepository },
+  );
+  for (const major of release.angularMajors) {
+    await run(
+      'npm',
+      [
+        'run',
+        'verify:consumer',
+        '--',
+        major,
+        '--package-root',
+        repositoryPath,
+      ],
+      { cwd: automationRepository },
+    );
   }
 }
 
@@ -269,7 +361,7 @@ async function packRelease(repositoryPath) {
 
 export async function validateRelease(version, repositoryPath = resolveRepository()) {
   const { release, npmUser } = await assertReleaseState(repositoryPath, version);
-  await runValidation(repositoryPath);
+  await runValidation(repositoryPath, release);
   const packed = await packRelease(repositoryPath);
   try {
     return {
@@ -300,7 +392,8 @@ export async function publishRelease(
   }
 
   const { release, npmUser } = await assertReleaseState(repositoryPath, version);
-  await runValidation(repositoryPath);
+  await assertPrerequisite(repositoryPath, version, release);
+  await runValidation(repositoryPath, release);
   const packed = await packRelease(repositoryPath);
   try {
     const result = await run(

--- a/tools/npm-publisher-mcp/test/release.test.mjs
+++ b/tools/npm-publisher-mcp/test/release.test.mjs
@@ -8,19 +8,31 @@ import {
   getRelease,
   readPackageVersions,
   ReleaseError,
+  resolveReleaseRepository,
 } from '../src/release.mjs';
 
-test('release policy only permits the Angular 21 prerelease and final release', () => {
-  assert.deepEqual(getRelease('21.0.0-next.0'), { tag: 'next', prerequisite: null });
-  assert.deepEqual(getRelease('21.0.0'), {
-    tag: 'latest',
-    prerequisite: '21.0.0-next.0',
-  });
-  assert.throws(() => getRelease('20.0.0'), ReleaseError);
+test('release policy permits the chronological Angular 17 through 21 release train', () => {
+  assert.equal(getRelease('17.0.0').tag, 'angular17');
+  assert.equal(getRelease('17.0.0').branch, 'release/17.0.0');
+  assert.equal(getRelease('18.0.0').prerequisite, '17.0.0');
+  assert.equal(getRelease('19.0.0').prerequisite, '18.0.0');
+  assert.equal(getRelease('20.0.0').prerequisite, '19.0.0');
+  assert.equal(getRelease('21.0.0-next.0').prerequisite, '20.0.0');
+  assert.equal(getRelease('21.0.0').tag, 'latest');
+  assert.equal(getRelease('21.0.0').prerequisite, '21.0.0-next.0');
+  assert.throws(() => getRelease('16.0.5'), ReleaseError);
   assert.throws(() => getRelease('21.0.1'), ReleaseError);
 });
 
 test('confirmation phrase binds the package, version, and dist-tag', () => {
+  assert.equal(
+    confirmationPhrase('17.0.0'),
+    'publish ngx-mat-select@17.0.0 with tag angular17',
+  );
+  assert.equal(
+    confirmationPhrase('20.0.0'),
+    'publish ngx-mat-select@20.0.0 with tag angular20',
+  );
   assert.equal(
     confirmationPhrase('21.0.0-next.0'),
     'publish ngx-mat-select@21.0.0-next.0 with tag next',
@@ -29,6 +41,13 @@ test('confirmation phrase binds the package, version, and dist-tag', () => {
     confirmationPhrase('21.0.0'),
     'publish ngx-mat-select@21.0.0 with tag latest',
   );
+});
+
+test('historical releases resolve to isolated worktrees', () => {
+  const root = path.resolve('D:\\ngx-mat-select');
+  assert.equal(resolveReleaseRepository('17.0.0', root), path.resolve(`${root}-release-17`));
+  assert.equal(resolveReleaseRepository('20.0.0', root), path.resolve(`${root}-release-20`));
+  assert.equal(resolveReleaseRepository('21.0.0-next.0', root), root);
 });
 
 test('package version reader rejects a different library package', async () => {


### PR DESCRIPTION
## What changed

- expand the guarded npm release policy to `17.0.0` through `21.0.0`
- bind Angular 17–20 releases to isolated version-specific worktrees and non-`latest` dist-tags
- enforce chronological publication prerequisites and exact per-release confirmation phrases
- extend clean-consumer validation to Angular 17, 18, and 19 and allow validation against historical package roots
- make public API verification work with both split and flattened declaration output
- document the compatibility release train

## Why

Angular 17–20 were originally migration checkpoints and could not be published safely. Each package now has a guarded path that builds its matching checkpoint without changing the Angular 21 main worktree or npm's `latest` tag.

## Validation

- publisher server tests: 5/5
- master public API build and verification
- Angular 17–20 clean installs
- Angular 17–20 library tests: 12/12 per major
- Angular 17–20 production library builds
- Angular 17–20 packed-artifact and peer-dependency inspection
- Angular 17–20 clean consumer tests and production builds

No npm publication occurs in this PR.