### PR TITLE
Fix GitHub Pages documentation runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "21.0.0-next.0",
+  "version": "21.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-select-workspace",
-      "version": "21.0.0-next.0",
+      "version": "21.0.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^21.2.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select-workspace",
-  "version": "21.0.0-next.0",
+  "version": "21.0.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/projects/ngx-mat-select/package.json
+++ b/projects/ngx-mat-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-select",
-  "version": "21.0.0-next.0",
+  "version": "21.0.0",
   "license": "MIT",
   "author": "Alireza Sohrabi, Tehran IRAN",
   "bugs": {

--- a/projects/ngx-mat-select/src/lib/component/search-box/ngx-mat-select-search-box.component.spec.ts
+++ b/projects/ngx-mat-select/src/lib/component/search-box/ngx-mat-select-search-box.component.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { NgxMatSelectSearchBoxComponent } from './ngx-mat-select-search-box.component';
+import { NgxMatSelectSearchBoxModule } from './ngx-mat-select-search-box.module';
+
+describe('NgxMatSelectSearchBoxComponent', () => {
+  let component: NgxMatSelectSearchBoxComponent;
+  let fixture: ComponentFixture<NgxMatSelectSearchBoxComponent>;
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxMatSelectSearchBoxModule],
+    });
+
+    fixture = TestBed.createComponent(NgxMatSelectSearchBoxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    input = fixture.nativeElement.querySelector('input');
+  });
+
+  it('emits the entered search term after the configured debounce', fakeAsync(() => {
+    const terms: string[] = [];
+    component.search.subscribe((term) => terms.push(term));
+
+    input.value = 'pizza';
+    input.dispatchEvent(new Event('input'));
+    tick(component.debounceTime - 1);
+    expect(terms).toEqual([]);
+
+    tick(1);
+    expect(terms).toEqual(['pizza']);
+  }));
+
+  it('clears the value and emits an empty search term', () => {
+    const terms: string[] = [];
+    component.search.subscribe((term) => terms.push(term));
+    component.value = 'pizza';
+    component.clear();
+
+    expect(component.value).toBe('');
+    expect(terms).toEqual(['']);
+  });
+
+  it('tracks focus and forwards keyboard events', () => {
+    const keys: KeyboardEvent[] = [];
+    component.handleKeydown.subscribe((event) => keys.push(event));
+
+    input.dispatchEvent(new Event('blur'));
+    expect(component.focused).toBeFalse();
+
+    input.dispatchEvent(new Event('focus'));
+    const keydown = new KeyboardEvent('keydown', { code: 'ArrowDown' });
+    input.dispatchEvent(keydown);
+
+    expect(component.focused).toBeTrue();
+    expect(keys).toEqual([keydown]);
+  });
+});

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,9 +1,13 @@
 import {
   NgDocDefaultSearchEngine,
+  NG_DOC_DEFAULT_PAGE_PROCESSORS,
+  NG_DOC_DEFAULT_PAGE_SKELETON,
   NgDocNavbarComponent,
   NgDocRootComponent,
   NgDocSidebarComponent,
   provideNgDocApp,
+  provideMainPageProcessor,
+  providePageSkeleton,
   provideSearchEngine,
 } from '@ng-doc/app';
 import {NG_DOC_ROUTING, provideNgDocContext} from '@ng-doc/generated';
@@ -39,6 +43,8 @@ export const ngxMatSelectConfigs: NgxMatSelectConfig = {}
   providers: [
     {provide: NGX_MAT_SELECT_CONFIG, useValue: ngxMatSelectConfigs},
     provideNgDocApp(),
+    providePageSkeleton(NG_DOC_DEFAULT_PAGE_SKELETON),
+    provideMainPageProcessor(NG_DOC_DEFAULT_PAGE_PROCESSORS),
     provideNgDocContext(),
     provideSearchEngine(NgDocDefaultSearchEngine)
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import {NG_DOC_ROUTING, provideNgDocContext} from '@ng-doc/generated';
 import {RouterModule} from "@angular/router";
 import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
+import {provideHttpClient} from '@angular/common/http';
 
 import {AppComponent} from './app.component';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
@@ -46,7 +47,8 @@ export const ngxMatSelectConfigs: NgxMatSelectConfig = {}
     providePageSkeleton(NG_DOC_DEFAULT_PAGE_SKELETON),
     provideMainPageProcessor(NG_DOC_DEFAULT_PAGE_PROCESSORS),
     provideNgDocContext(),
-    provideSearchEngine(NgDocDefaultSearchEngine)
+    provideSearchEngine(NgDocDefaultSearchEngine),
+    provideHttpClient()
   ],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
## What changed

- add the missing NgDoc page skeleton and processor providers
- register Angular HttpClient for NgDoc runtime services
- add search-box regression coverage
- finalize the stable 21.0.0 package metadata

## Why

The deployed GitHub Pages application loaded its navigation but failed to render documentation content with Angular NG0201 because NgDoc runtime dependencies were not fully provided.

## Impact

After merge, the existing Build and Deploy workflow will rebuild and publish dist/demo/browser to GitHub Pages. The documentation content and interactive select examples will render again.

## Validation

- 15/15 v21 workspace tests passed
- public TypeScript, selector, and Sass API verification passed
- clean Angular 21 consumer tests and production build passed
- production browser test passed: render, open select, filter options, select result, close overlay
- ngx-mat-select@21.0.0 is published and verified on npm