### PR TITLE
Fix documentation API, compatibility, and theme controls

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,7 +32,7 @@
               },
               {
                 "glob": "**/*",
-                "input": "ng-doc/ngx-mat-select/assets",
+                "input": "ng-doc/demo/assets",
                 "output": "assets/ng-doc"
               },
               "src/favicon.ico",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "test:ci": "npm run test -- --progress=false --code-coverage --source-map=true",
     "packagr": "npm run build:library",
     "pack:library": "npm pack ./dist/ngx-mat-select",
-    "build:ci": "npm run build:library && ng build demo --configuration production --progress=false --base-href=/ngx-mat-select/",
+    "build:ci": "npm run build:library && ng build demo --configuration production --progress=false --base-href=/ngx-mat-select/ && npm run verify:docs",
     "verify:consumer:21": "node scripts/verify-consumer.mjs 21",
     "verify:consumer:22": "node scripts/verify-consumer.mjs 22",
     "verify:consumer": "node scripts/verify-consumer.mjs",
-    "verify:public-api": "npm run build:library && node scripts/verify-public-api.mjs"
+    "verify:public-api": "npm run build:library && node scripts/verify-public-api.mjs",
+    "verify:docs": "node scripts/verify-docs-build.mjs"
   },
   "author": "Alireze Sohrabi, Tehran IRAN",
   "bugs": {

--- a/scripts/verify-docs-build.mjs
+++ b/scripts/verify-docs-build.mjs
@@ -1,0 +1,28 @@
+import {existsSync, readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const docsAssets = resolve(root, 'dist/demo/browser/assets/ng-doc');
+const apiListPath = resolve(docsAssets, 'api-list.json');
+const keywordsPath = resolve(docsAssets, 'keywords.json');
+
+for (const assetPath of [apiListPath, keywordsPath]) {
+  if (!existsSync(assetPath)) {
+    throw new Error(`Missing generated NgDoc asset: ${assetPath}`);
+  }
+}
+
+const apiList = JSON.parse(readFileSync(apiListPath, 'utf8'));
+const apiNames = apiList.flatMap((scope) => scope.items).map((item) => item.name);
+
+for (const requiredName of [
+  'NgxMatSelectComponent',
+  'NgxMatSelectModule',
+  'NgxMatSelectConfig',
+]) {
+  if (!apiNames.includes(requiredName)) {
+    throw new Error(`Missing generated API reference: ${requiredName}`);
+  }
+}
+
+console.log(`Generated documentation includes ${apiNames.length} API references and search keywords.`);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,6 +3,7 @@
 		<ng-template ngDocNavbarLeft>
 			<h3 style="margin: 0">NgxMatSelect Documents</h3>
 		</ng-template>
+		<ng-doc-theme-toggle ngDocNavbarRight></ng-doc-theme-toggle>
 	</ng-doc-navbar>
 	<ng-doc-sidebar></ng-doc-sidebar>
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import {provideHttpClient} from '@angular/common/http';
 import {AppComponent} from './app.component';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {NGX_MAT_SELECT_CONFIG, NgxMatSelectConfig} from 'ngx-mat-select';
+import {NgDocThemeToggleComponent} from '@ng-doc/app/components/theme-toggle';
 
 export const ngxMatSelectConfigs: NgxMatSelectConfig = {}
 
@@ -31,6 +32,7 @@ export const ngxMatSelectConfigs: NgxMatSelectConfig = {}
     BrowserAnimationsModule,
     NgDocRootComponent,
     NgDocNavbarComponent,
+    NgDocThemeToggleComponent,
     NgDocSidebarComponent,
     RouterModule.forRoot([...NG_DOC_ROUTING,
       {path: '', redirectTo: 'introduction', pathMatch: 'full'},

--- a/src/app/documents/version-compatibility/index.md
+++ b/src/app/documents/version-compatibility/index.md
@@ -1,7 +1,20 @@
 
 
-| Angular Material | 	NgxMatSelect |
-|------------------|---------------|
-| 16.x.x           | 	>= 16        | 
-| 15.x.x           | 	>= 15        | 
-| 14.x.x           | 	>= 14        | 
+Each `ngx-mat-select` major version targets the matching Angular and Angular Material major version.
+
+| Angular | Angular Material | ngx-mat-select |
+|---------|------------------|----------------|
+| 21.x    | 21.x             | 21.x           |
+| 20.x    | 20.x             | 20.x           |
+| 19.x    | 19.x             | 19.x           |
+| 18.x    | 18.x             | 18.x           |
+| 17.x    | 17.x             | 17.x           |
+| 16.x    | 16.x             | 16.x           |
+| 15.x    | 15.x             | 15.x           |
+| 14.x    | 14.x             | 14.x           |
+
+Install the package major that matches your Angular application:
+
+```bash
+npm install ngx-mat-select@21
+```

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -39,7 +39,8 @@ $angular-dark-theme: mat.m2-define-dark-theme(
   text-align: right;
 }
 
-.darkMode {
+.darkMode,
+html[data-theme="dark"] {
   @include mat.all-component-themes($angular-dark-theme);
   @include ngxMatSelect.theme($angular-dark-theme);
 }


### PR DESCRIPTION
## What changed

- publish the Angular 14–21 compatibility matrix
- copy the current generated NgDoc API/search assets into the deployed site
- add a build-time guard for missing API documentation assets
- add NgDoc's persisted Auto/Light/Dark toggle to the navbar
- apply the library and Angular Material dark palettes when NgDoc selects dark mode

## Root cause

The demo build copied API assets from an obsolete generated directory. The API landing page therefore requested `assets/ng-doc/api-list.json`, received a 404, and could not render its declarations.

## Validation

- `npm run build:ci`
- local browser: compatibility rows 14–21 render
- local browser: API landing page lists 15 references and filtering/navigation work
- local browser: theme switches to dark and remains dark after reload
