### PR TITLE
Fix documentation dark theme

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -40,6 +40,7 @@
             ],
             "styles": [
               "node_modules/@ng-doc/app/styles/global.css",
+              "node_modules/@ng-doc/app/styles/themes/dark.css",
               "src/styles.scss"
             ],
             "stylePreprocessorOptions": {


### PR DESCRIPTION
## What changed

- bundle NgDoc's dark-theme stylesheet with the documentation application
- allow the existing navbar theme toggle to style the complete explorer shell

## Root cause

The toggle set `data-theme="dark"`, but only NgDoc's base stylesheet was included. The dark CSS variables and syntax-highlighting colors were therefore unavailable, leaving the explorer visually light.

## Validation

- `npm run build:ci`
- browser-tested the production build in dark mode
- confirmed the navbar, sidebar, page, code samples, and component demo use the dark palette after reload
